### PR TITLE
Improve getCPUInfo() CPU-name regex

### DIFF
--- a/terminal/status.sh
+++ b/terminal/status.sh
@@ -55,7 +55,7 @@ getKernelInfo()
 
 getCPUInfo()
 {
-	sed -nE '0,/model name/s/^model name\s*:\s*(.*)\s+@/\1/p' /proc/cpuinfo
+	sed -nE '0,/^\s*model name/s/^\s*model name\s*:\s*(.*)\b\s+@/\1/p' /proc/cpuinfo
 }
 
 


### PR DESCRIPTION
- Allow leading spaces on matching of string "model name"
- Introduce word boundary at end of CPU model name matching before `@`-sign, this makes sure to not include any potential trailing spaces at CPU model name

Signed-off-by: Sami Olmari <sami@olmari.fi>