### PR TITLE
Make getOSInfo() check specific files for info

### DIFF
--- a/terminal/status.sh
+++ b/terminal/status.sh
@@ -43,7 +43,15 @@
 
 getOSInfo()
 {
-	sed -En 's/PRETTY_NAME="(.*)"/\1/p' /etc/*-release
+	if [ -f /etc/os-release ]; then
+		local result=$(sed -En 's/PRETTY_NAME="(.*)"/\1/p' /etc/os-release)
+	elif [ -f /usr/lib/os-release ]; then
+		local result=$(sed -En 's/PRETTY_NAME="(.*)"/\1/p' /usr/lib/os-release)
+	else
+		local result="N/A"	
+	fi
+
+	printf "$result"
 }
 
 


### PR DESCRIPTION
Instead scanning trough every possible file that ends with "-release"
check wether "os-release" file exist in known locations and use one
of them. If none exist print "N/A".

Fixes https://github.com/andresgongora/scripts/issues/65

Signed-off-by: Sami Olmari <sami@olmari.fi>