### PR TITLE
Make the installer prompt the user about what to do

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -30,12 +30,10 @@
 
 
 
-
-
-
 ##==============================================================================
 ##	FUNCTIONS
 ##==============================================================================
+
 
 ##------------------------------------------------------------------------------
 ##
@@ -55,10 +53,13 @@ installScript()
 	local script_name=$2	
 
 
+	## EXTERNAL VARIABLES
+	if [ -z $INSTALL_DIR ]; then echo "INSTALL_DIR not set"; exit 1; fi
+	if [ -z $BASHRC ];      then echo "BASHRC not set";      exit 1; fi
+	if [ -z $CONFIG_DIR ];  then echo "CONFIG_DIR not set";  exit 1; fi
+
+
 	## LOCAL VARIABLES
-	local INSTALL_DIR="/usr/local/bin" 
-	local CONFIG_DIR="/etc/andresgongora/scripts"
-	local BASHRC="/etc/bash.bashrc"
 	local dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 	local script="${INSTALL_DIR}/${script_name}.sh"
 	local source_script="${dir}/../terminal/${script_name}.sh"
@@ -83,24 +84,21 @@ installScript()
 		## REMOVE HOOK
 		editTextFile "$BASHRC" delete "$hook"
 
-
-
 		## REMOVE SCRIPT
 		if [ -f $script ]; then
 			rm $script
 		fi
-
-
-
-		## REMOVE CONFIG FILES
-		if [ -d $CONFIG_DIR ]; then
-			rm -r  $CONFIG_DIR
-		fi
-		
-
 		;;
 
+
 	install)
+
+		## CHECK THAT INSTALL DIR EXISTS
+		if [ ! -d $INSTALL_DIR ]; then
+			mkdir -p $INSTALL_DIR
+		fi
+
+
 
 		## CREATE EMPTY SCRIPT FILE	
 		if [ -f $script ]; then
@@ -199,25 +197,135 @@ uninstallAll()
 ##	MAIN
 ##==============================================================================
 
+##------------------------------------------------------------------------------
+##
+installerSystem()
+{
+	local option=$1
+	local INSTALL_DIR="/usr/local/bin" 
+	local CONFIG_DIR="/etc/andresgongora/scripts"
+	local BASHRC="/etc/bash.bashrc"
+
+	if [ $(id -u) -ne 0 ];
+		then echo "Please run as root"
+		exit
+	fi
+
+	case "$option" in
+		uninstall)	printf 'Uninstalling...\n'
+				uninstallAll
+				;;
+		""|install)	printf 'Installing...\n'
+				installAll
+				;;
+		*)		echo "Usage: $0 {install|uninstall}" & exit 1
+	esac
+}
 
 
-if [ $(id -u) -ne 0 ];
-	then echo "Please run as root"
-	exit
-fi
+
+
+##------------------------------------------------------------------------------
+##
+installerUser()
+{
+	local option=$1
+	local INSTALL_DIR="${HOME}/.config/scripts" 
+	local CONFIG_DIR="${HOME}/.config/scripts" 
+	local BASHRC="${HOME}/.bashrc" 
+
+	case "$option" in
+		uninstall)	printf 'Uninstalling...\n'
+				uninstallAll
+				;;
+		""|install)	printf 'Installing...\n'
+				installAll
+				;;
+		*)		echo "Usage: $0 {install|uninstall}" & exit 1
+	esac
+}
 
 
 
-case "$1" in
-	uninstall)	uninstallAll;;
-	"")		installAll ;;
-	install)	installAll ;;
-	*)
-		echo $"Usage: $0 {install|uninstall}"
-            	exit 1
-esac
 
 
+##------------------------------------------------------------------------------
+##
+##	PROMPT USER FOR INSTALLATION OPTIONS
+##
+##	USER INSTALL ONLY:	Will all code to user's home dir
+##	                  	and add hooks to its own bashrc file.
+##	SYSTEM WIDE INSTALL:	Will add code to system and hooks to
+##	                    	/etc/bash.bashrc file.
+##
+promptUser()
+{
+	local install_option=""
+	local action=""
+
+
+
+	## CHOSE INSTALL OPTION: INSTALL/UNINTSALL
+	printf 'This script will install/remove '
+	printf 'status.sh and fancy-bash-prompt.sh\n'
+	printf 'Would you like to [i]nstall or [u]ninstall it?\n'
+	printf '[i]/u: '
+
+	exec 6<&0
+	exec 0<$(tty)
+	read -n 1 action
+	exec 0<&6 6<&-
+
+	case "$action" in
+		""|i|I )	printf '\nInstalling...\n\n'
+				local install_option="install"
+				;;
+		u|U )		printf '\nUninstalling...\n\n'
+				local install_option="uninstall"
+				;;
+		*)		echo "Invalid option"
+				exit 1
+	esac
+
+
+
+	## CHOOSE SCOPE: USER/SYSTEM
+	printf "For [u]ser $USER only (recommended) "
+	printf 'or [s]ystem wide (requires elevated privileges)?\n'
+	printf '[u]/s?: '
+	
+	exec 6<&0
+	exec 0<$(tty)
+	read -n 1 action
+	exec 0<&6 6<&-			
+
+	case "$action" in
+		""|u|U )	printf "\nRunning for user $USER\n\n"
+				installerUser   $install_option
+				;;
+		s|S )		printf "\nRunning systemwide\n\n"
+				sudo bash -c "bash $0 $install_option"
+				;;
+		*)		echo "\nInvalid option"
+				exit 1
+	esac
+}
+
+
+
+
+##------------------------------------------------------------------------------
+##
+installer()
+{
+	case "$1" in
+		install|uninstall)	installerSystem "$1";;
+		*)			promptUser ;;
+	esac
+}
+
+
+installer $1
 
 
 

--- a/terminal/fancy-bash-prompt.sh
+++ b/terminal/fancy-bash-prompt.sh
@@ -152,10 +152,11 @@ bash_prompt() {
 	## LOAD USER CONFIGURATION
 	local user_config_file="$HOME/.config/scripts/fancy-bash-prompt.config"
 	local sys_config_file="/etc/andresgongora/scripts/fancy-bash-prompt.config"
+	if [ -f $sys_config_file ]; then
+		loadConfigFile $sys_config_file
+	fi
 	if [ -f $user_config_file ]; then
 		loadConfigFile $user_config_file
-	elif [ -f $sys_config_file ]; then
-		loadConfigFile $sys_config_file
 	fi
 
 

--- a/terminal/status.sh
+++ b/terminal/status.sh
@@ -751,10 +751,11 @@ local date_format="%Y.%m.%d - %T"
 ## LOAD USER CONFIGURATION
 local user_config_file="$HOME/.config/scripts/status.config"
 local sys_config_file="/etc/andresgongora/scripts/status.config"
+if [ -f $sys_config_file ]; then
+	loadConfigFile $sys_config_file
+fi
 if [ -f $user_config_file ]; then
 	loadConfigFile $user_config_file
-elif [ -f $sys_config_file ]; then
-	loadConfigFile $sys_config_file
 fi
 
 


### PR DESCRIPTION
Backwards compatible if install/uninstall specified when calling the installer

Still, very UGLY. In the future the installer must be cleaned up a bit

Signed-off-by: Andres Gongora <andresgongora@uma.es>