### PR TITLE
Make systemctl show all failed units

### DIFF
--- a/terminal/status.sh
+++ b/terminal/status.sh
@@ -649,7 +649,7 @@ printSystemctl()
 	systcl_num_failed=$(systemctl --failed | grep "loaded units listed" | head -c 1)
 
 	if [ "$systcl_num_failed" -ne "0" ]; then
-		local failed=$(systemctl --failed | grep ".service")
+		local failed=$(systemctl --failed | systemctl --failed|awk '/UNIT/,/^$/')
 		printf "${fc_crit}SYSTEMCTL FAILED SERVICES:\n"
 		printf "${fc_info}${failed}${fc_none}\n\n"
 


### PR DESCRIPTION
Essentially this change will show the header for systemctl and
then all failed units regardless of "type", until there comes newline.

Signed-off-by: Sami Olmari <sami@olmari.fi>