### PR TITLE
Installation Error Fixed

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -121,6 +121,8 @@ installScript()
 		echo "" >> ${script}
 		cat "${dir}/../common/color.sh" >> "$script"
 		echo "" >> ${script}
+		cat "${dir}/../common/shorten_path.sh" >> "$script"
+		echo "" >> ${script}
 
 		cat "$source_script" >> "$script"
 


### PR DESCRIPTION
Once I try to install it again from latest merged you made. I found error because shorten_path.sh didn't copy to the fancy sh, and I found the solution.

![image](https://user-images.githubusercontent.com/32075735/59474343-92176980-8e70-11e9-8812-0204bca262bd.png)
