### PR TITLE
Bug Fixed and Updates

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -192,17 +192,9 @@ installAll()
 	esac
 
 
-	printf 'Install fancy-bash-prompt.sh? [y]/n: '
 
-	exec 6<&0
-	exec 0<$(tty)
-	read -n 1 action
-	exec 0<&6 6<&-
-
-	case "$action" in
-		""|y|Y )	installScript install "fancy-bash-prompt" ;;
-		*)		echo ""
-	esac
+	# installing fancy-bash-promt
+	installScript install "fancy-bash-prompt"
 }
 
 

--- a/terminal/fancy-bash-prompt.sh
+++ b/terminal/fancy-bash-prompt.sh
@@ -77,7 +77,7 @@ printSegment()
 	local background_color=$3
 	local next_background_color=$4
 	local font_effect=$5
-	if [ -z "$separator_char" ]; then echo "separator_char is blank"; local separator_char="X"; fi
+	local separator_char=$'\uE0B0'
 
 
 
@@ -192,9 +192,9 @@ prompt_command_hook()
 	local background_input="none"
 	local texteffect_input="bold"
 
-	local separator_char=$'\uE0B0'
 	local enable_vertical_padding=true
-	local show_git=false
+	# If you want to hide current git branch name, set it's value to "false"
+	local show_git=true
 
 
 


### PR DESCRIPTION
Bug Fixed:
- Separator character error fixed.
Updates:
- fancy-bash-promt automatically installed.
- current git branch name information's default set to show.

---

I don't know did I miss something or what. But once I install it, I get an error on separator, But I though I was fixed it:

![image](https://user-images.githubusercontent.com/32075735/59551736-69928b00-8fa8-11e9-85ba-7d3637f2d8f7.png)

And I think(as an user) fancy-bash-promt is what people want to have, so I think it's better to automatically install it. And git branch information is something what makes this repo difference :)

I hope you like this update, if you don't feel free to change it